### PR TITLE
#20: Add opencv as submodule.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ install_manifest.txt
 # OSX files
 .DS_Store
 
+out
+

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "build/cpplint"]
 	path = build/cpplint
 	url = https://github.com/it-workshop/caroline-thirdparty-cpplint-mirror.git
+[submodule "third_party/opencv"]
+	path = third_party/opencv
+	url = https://github.com/it-workshop/caroline-thirdparty-opencv-mirror.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,16 @@
 cmake_minimum_required(VERSION 2.8.12)
 project (Caroline CXX)
 
+if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+  set (default_use_own_opencv OFF)
+else ()
+  set (default_use_own_opencv ON)
+endif ()
+
+option(use_own_opencv
+  "Own sources of opencv will be used on the non-linux systems."
+  ${default_use_own_opencv})
+
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(cxx11_support)
 include(platform_utils)
@@ -25,8 +35,17 @@ if (DEFINED cxx11_flag)
   add_definitions("${cxx11_flag}")
 endif ()
 
-find_package(OpenCV REQUIRED)
-
+if (NOT use_own_opencv)
+  find_package(OpenCV REQUIRED)
+else ()
+  file (GLOB OpenCV_INCLUDE_DIRS
+      "${CMAKE_SOURCE_DIR}/third_party/opencv/modules/*/include")
+  list (APPEND OpenCV_INCLUDE_DIRS
+      "${CMAKE_SOURCE_DIR}/third_party/opencv/include")
+  set (OpenCV_LIBS
+    opencv_core
+    )
+endif ()
 include_directories("${OpenCV_INCLUDE_DIRS}")
 
 include_directories("${CMAKE_SOURCE_DIR}")

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -6,3 +6,7 @@
 cmake_minimum_required(VERSION 2.8.12)
 
 add_subdirectory(gtest)
+
+if (use_own_opencv)
+  add_subdirectory(opencv)
+endif ()


### PR DESCRIPTION
За включение/отключение своей сборки opencv отвечает опция `use_own_opencv` `-Duse_own_opencv=(ON|OFF)` для cmake. На линуксе эта опция по умолчанию выключена, на остальных платформах включена.

Сборка opencv занимает дополнительные десять минут при сборке с нуля, однако время инкрементальной сборки увеличилось всего на пару секунд.

Этот пулл-реквест потребует обновить субмодули (`git submodule update`).
